### PR TITLE
configure benchmarks to properly run on CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           julia -e '
             using BenchmarkCI
-            BenchmarkCI.judge()
+            BenchmarkCI.judge(baseline = "origin/main")
             BenchmarkCI.displayjudgement()
             '
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 Manifest.toml
 .vscode
+/.benchmarkci
+/benchmark/*.json

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 QuantumClifford = "0525e862-1e90-11e9-3e4d-1b39d7109de1"
 QuantumOpticsBase = "4f57444f-1401-5e15-980d-4471b28d5678"
 QuantumSymbolics = "efa7fd63-0460-4890-beb7-be1bbdfbaeae"

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+QuantumClifford = "0525e862-1e90-11e9-3e4d-1b39d7109de1"
+QuantumOpticsBase = "4f57444f-1401-5e15-980d-4471b28d5678"
+QuantumSymbolics = "efa7fd63-0460-4890-beb7-be1bbdfbaeae"


### PR DESCRIPTION
BenchmarkCI needs Project.toml and defaults to "master" not "main"